### PR TITLE
Fixed a problem with strange behaviour of LiveObject JSObject.getMember()

### DIFF
--- a/nsjsobject/src/java/mjson/nsjsobject/NetscapeJsonFactory.java
+++ b/nsjsobject/src/java/mjson/nsjsobject/NetscapeJsonFactory.java
@@ -89,7 +89,12 @@ public class NetscapeJsonFactory extends Json.DefaultFactory implements java.io.
         
         public boolean has(String property)
         {
-            return object.getMember(property) != null;
+            // based on this: https://developer.mozilla.org/en-US/docs/Archive/Web/LiveConnect/LiveConnect_Overview#Undefined_Values
+            // "The value is converted to an instance of java.lang.String whose value is the string "undefined"."
+            // and this: http://mail.openjdk.java.net/pipermail/nashorn-dev/2015-March/004418.html
+            return !object
+                    .eval(String.format("typeof this['%s']", property))
+                    .equals("undefined");
         }
         
         public boolean is(String property, Object value) 


### PR DESCRIPTION
Fixed a problem with strange behaviour of LiveObject `JSObject.getMember()`.
You may check these links:
[https://developer.mozilla.org/en-US/docs/Archive/Web/LiveConnect/LiveConnect_Overview#Undefined_Values](https://developer.mozilla.org/en-US/docs/Archive/Web/LiveConnect/LiveConnect_Overview#Undefined_Values)

> The value is converted to an instance of java.lang.String whose value is the string "undefined".

[http://mail.openjdk.java.net/pipermail/nashorn-dev/2015-March/004418.html](http://mail.openjdk.java.net/pipermail/nashorn-dev/2015-March/004418.html)