### PR TITLE
 Fixed a problem with Json.at(String property, Json def)

### DIFF
--- a/nsjsobject/src/java/mjson/nsjsobject/NetscapeJsonFactory.java
+++ b/nsjsobject/src/java/mjson/nsjsobject/NetscapeJsonFactory.java
@@ -108,7 +108,10 @@ public class NetscapeJsonFactory extends Json.DefaultFactory implements java.io.
         
         public Json at(String property)
         {
-            return make(object.getMember(property));
+            if (has(property))
+                return make(object.getMember(property));
+            else
+                return null;
         }
 
         protected Json withOptions(Json other, Json allOptions, String path)


### PR DESCRIPTION
 Fixed a problem with Json.at(String property, Json def) method.
Because JsonObject.at(String property) returns "undefined" if the wrapped JSObject does not contain the specified property then Json.at(String property, Json def) returns "undefined" instead of the passed `def` value.
Since Json.at(String property, Json def) is final and cannot be redefined in a subclass then JsonObject.at(String property) is modified to return `null` when the property is not present in the object.